### PR TITLE
Allow the time-series name to be retrieved from the result row

### DIFF
--- a/lib/InfluxPHP/Result.php
+++ b/lib/InfluxPHP/Result.php
@@ -37,19 +37,29 @@
 
 namespace crodas\InfluxPHP;
 
-use ArrayIterator;
-
-class Cursor extends ArrayIterator
+class Result
 {
-    public function __construct(array $resultset)
+
+    private $data;
+    private $timeSeriesName;
+
+    public function __construct(array $data, $timeSeriesName)
     {
-        $rows = [];
-        foreach ($resultset as $set) {
-            foreach ($set['points'] as $row) {
-                $row    = new Result(array_combine($set['columns'], $row), $set['name']);
-                $rows[] = $row;
-            }
-        }
-        parent::__construct($rows);
+        $this->data = $data;
+        $this->timeSeriesName = $timeSeriesName;
     }
+
+    public function getTimeSeriesName()
+    {
+        return $this->timeSeriesName;
+    }
+
+    public function __get($key)
+    {
+        if (array_key_exists($key, $this->data)) {
+            return $this->data[$key];
+        }
+        throw new \InvalidArgumentException('Missing key: ' . $key);
+    }
+
 }


### PR DESCRIPTION
InfluxDB supports querying multiple time-series at the same time.

With that in mind, it's crucially important to figure out which
result row comes from which time-series in order to make sense
of the data.

The current implementation preserves backwards compatibility
with the old way of doing things with the only exception of
throwing an InvalidArgumentException exception when accessing
a missing key.
