### PR TITLE
PHP5.3 compatibility and InfluxDB deprecated features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 script: phpunit
 
 php:
+    - 5.3
     - 5.4
     - 5.5
 

--- a/lib/InfluxPHP/BaseHTTP.php
+++ b/lib/InfluxPHP/BaseHTTP.php
@@ -64,9 +64,9 @@ class BaseHTTP
         $c->children[] = $this;
     }
 
-    protected function getCurl($url, array $args = [])
+    protected function getCurl($url, array $args = array())
     {
-        $args = array_merge($args, ['u' => $this->user, 'p' => $this->pass]);
+        $args = array_merge($args, array('u' => $this->user, 'p' => $this->pass));
         $url  = "http://{$this->host}:{$this->port}/{$this->base}{$url}";
         $url .= "?" . http_build_query($args);
         $ch   = curl_init($url);
@@ -89,9 +89,9 @@ class BaseHTTP
     protected function delete($url)
     {
         $ch = $this->getCurl($url);
-        curl_setopt_array($ch, [
+        curl_setopt_array($ch, array(
             CURLOPT_CUSTOMREQUEST => "DELETE",
-        ]);
+        ));
 
         return $this->execCurl($ch);
     }
@@ -119,19 +119,19 @@ class BaseHTTP
         throw new \InvalidArgumentException("Expecting s, m or u as time precision");
     }
 
-    protected function get($url, array $args = [])
+    protected function get($url, array $args = array())
     {
         $ch = $this->getCurl($url, $args);
         return $this->execCurl($ch, true);
     }
 
-    protected function post($url, array $body, array $args = [])
+    protected function post($url, array $body, array $args = array())
     {
         $ch = $this->getCurl($url, $args);
-        curl_setopt_array($ch, [
+        curl_setopt_array($ch, array(
             CURLOPT_POST =>  1,
             CURLOPT_POSTFIELDS => json_encode($body),
-        ]);
+        ));
 
         return $this->execCurl($ch);
     }

--- a/lib/InfluxPHP/Client.php
+++ b/lib/InfluxPHP/Client.php
@@ -59,7 +59,7 @@ class Client extends BaseHTTP
 
     public function createDatabase($name)
     {
-        $this->post('db', ['name' => $name]);
+        $this->post('db', array('name' => $name));
         return new DB($this, $name);
     }
 

--- a/lib/InfluxPHP/Cursor.php
+++ b/lib/InfluxPHP/Cursor.php
@@ -43,7 +43,7 @@ class Cursor extends ArrayIterator
 {
     public function __construct(array $resultset)
     {
-        $rows = [];
+        $rows = array();
         foreach ($resultset as $set) {
             foreach ($set['points'] as $row) {
                 $row    = (object)array_combine($set['columns'], $row);

--- a/lib/InfluxPHP/DB.php
+++ b/lib/InfluxPHP/DB.php
@@ -62,17 +62,17 @@ class DB extends BaseHTTP
 
     public function insert($name, array $data)
     {
-        $points = [];
+        $points = array();
         $first  = current($data);
         if (!is_array($first)) {
-            return $this->insert($name, [$data]);
+            return $this->insert($name, array($data));
         }
         $columns = array_keys($first);
         foreach ($data as $value) {
             $points[] = array_values($value);
         }
         $body = compact('name', 'columns', 'points');
-        return $this->post('series', [$body], ['time_precision' => $this->timePrecision]);
+        return $this->post('series', array($body), array('time_precision' => $this->timePrecision));
     }
 
     public function first($sql)
@@ -82,7 +82,7 @@ class DB extends BaseHTTP
 
     public function query($sql)
     {
-        return new Cursor($this->get('series', ['q' => $sql, 'time_precision' => $this->timePrecision]));
+        return new Cursor($this->get('series', array('q' => $sql, 'time_precision' => $this->timePrecision)));
     }
 
     public function createUser($name, $password)

--- a/tests/DBTest.php
+++ b/tests/DBTest.php
@@ -69,7 +69,7 @@ class DBTest extends \PHPUnit_Framework_TestCase
     public function testInvalidTimePrecision()
     {
         $client = new Client;
-        $client->SetTimePrecision([]);
+        $client->SetTimePrecision(array());
     }
 
     public function testQuery()
@@ -78,9 +78,9 @@ class DBTest extends \PHPUnit_Framework_TestCase
         $db = $client->createDatabase("test_xxx");
         $db->createUser("root", "root");
 
-        $db->insert("foobar", ['type' => '/foobar', 'karma' => 10]);
-        $db->insert("foobar", ['type' => '/foobar', 'karma' => 20]);
-        $db->insert("foobar", ['type' => '/barfoo', 'karma' => 30]);
+        $db->insert("foobar", array('type' => '/foobar', 'karma' => 10));
+        $db->insert("foobar", array('type' => '/foobar', 'karma' => 20));
+        $db->insert("foobar", array('type' => '/barfoo', 'karma' => 30));
 
         $this->assertEquals($db->first("SELECT max(karma) FROM foobar")->max, 30);
         $this->assertEquals($db->first("SELECT min(karma) FROM foobar")->min, 10);


### PR DESCRIPTION
Compatibility with **PHP5.3**:
- `array()` syntax used instead of `[]`

Fixing the TravisCI build with **InfluxDB deprecated features**:
- `dbs` is changed to `db` in the latest InfluxDB when listing dbs
- `username` is changed to `name` in the latest InfluxDB when creating user
- `PHPUnit_Framework_TestCase` instead of `phpunit_framework_testcase`
- Grouping by anything but time does not return time anymore
