### PR TITLE
test timing problem hopefully fixed & PHP 5.3 test compatibility

### DIFF
--- a/lib/InfluxPHP/Client.php
+++ b/lib/InfluxPHP/Client.php
@@ -190,7 +190,8 @@ class Client extends BaseHTTP
     {
         return($this->get('query', array('q' => 'REVOKE ALL PRIVILEGES FROM ' . $user)));
     }
-
+    
+    
     /**
      * Get database 
      * 
@@ -201,7 +202,7 @@ class Client extends BaseHTTP
     {
         return new DB($this, $name);
     }
-
+    
     /**
      * Shortcut for getDatabase
      * 

--- a/lib/InfluxPHP/DB.php
+++ b/lib/InfluxPHP/DB.php
@@ -52,11 +52,21 @@ class DB extends BaseHTTP
         $this->base = '';
     }
 
+    /**
+     * Get database name
+     * 
+     * @return string
+     */
     public function getName()
     {
         return $this->name;
     }
 
+    /**
+     * Drop database
+     * 
+     * @return type
+     */
     public function drop()
     {
         return $this->client->deleteDatabase($this->name);
@@ -98,15 +108,74 @@ class DB extends BaseHTTP
         return $this->post('write', $body, array('db' => $this->name, 'time_precision' => $this->timePrecision));
     }
 
+    /**
+     * Get first element of query resultset
+     * 
+     * @param string $sql
+     * @return type
+     */
     public function first($sql)
     {
         return current($this->query($sql));
     }
 
+    /**
+     * Query database and get resultset 
+     * 
+     * @param string $sql
+     * @return type
+     */
     public function query($sql)
     {
         return ResultsetBuilder::buildResultSeries($this->get('query', array('db' => $this->name, 'q' => $sql, 'time_precision' => $this->timePrecision)));
       
     }
+    
+    /**
+     * Create retention policy of a database
+     * 
+     * @param type $name
+     * @param type $duration
+     * @param type $replication
+     * @param bool $default
+     * @return type
+     */
+    public function setRetentionPolicy($name, $duration, $replication, $default = false)
+    {
+        $query = 'CREATE RETENTION POLICY ' . $name . ' ON ' . $this->name . ' DURATION ' . $duration . ' REPLICATION ' . $replication . ($default ? ' DEFAULT' : '');
+        return $this->query($query);
+    }
 
+    /**
+     * Modify the retention policy of a database
+     * 
+     * @param type $name
+     * @param type $duration
+     * @param type $replication
+     * @param book $default
+     * @return type
+     */
+    public function modifyRetentionPolicy($name, $duration=null, $replication=null, $default = false)
+    {
+        // the parameters are optional, so don't set if null is submitted. In any other case, change the values. 
+        $query = 'ALTER RETENTION POLICY ' . $name . ' ON ' . $this->name .  
+                ($duration !== null ? ' DURATION ' . $duration : '') . 
+                ($replication !== null ? ' REPLICATION ' . $replication : '') . 
+                ($default === true ? ' DEFAULT' : '');
+        return $this->query($query);
+    }
+
+    
+    /**
+     * Show retention policies from database
+     * 
+     * @return type
+     */
+    public function getRetentionPolicies()
+    {
+        return($this->query('SHOW RETENTION POLICIES ' . $this->name));
+    }
+    
+    
+    
 }

--- a/tests/DBTest.php
+++ b/tests/DBTest.php
@@ -235,6 +235,56 @@ class DBTest extends \PHPUnit_Framework_TestCase
         $db = $client->createDatabase("test_zzz");
     }
 
+    
+    
+    /** 
+     * @depends testDatabaseExists
+     * @medium
+     */
+    public function testDefaultRetentionPolicy()
+    {
+        $client = new Client;
+        $db = $client->test_zzz;
+        $policy = $db->getRetentionPolicies();
+        $this->assertCount(1, $policy);
+        $this->assertEquals('default', $policy[0]->name);
+        $this->assertEquals(true, $policy[0]->default);
+        
+    }
+    
+    /** 
+     * @depends testDefaultRetentionPolicy
+     * @medium
+     */
+    public function testSetRetentionPolicy()
+    {
+        $client = new Client;
+        $db = $client->test_zzz;
+        $result = $db->setRetentionPolicy('testpolicy','1w',1);
+        $policy = $db->getRetentionPolicies();
+        
+        $this->assertCount(2, $policy);
+        
+    }
+    
+    /** 
+     * @depends testSetRetentionPolicy
+     * @medium
+     */
+    public function testGetRetentionPolicy()
+    {
+        $client = new Client;
+        $db = $client->test_zzz;
+       
+        $policy = $db->getRetentionPolicies();
+        
+        $this->assertCount(2, $policy);
+        $this->assertEquals('default', $policy[0]->name);
+        $this->assertEquals(true, $policy[0]->default);
+        $this->assertEquals('testpolicy', $policy[1]->name);
+        $this->assertEquals(false, $policy[1]->default);
+    }
+    
     public function lalala_testQuery()
     {
         $client = new Client;

--- a/tests/DBTest.php
+++ b/tests/DBTest.php
@@ -15,10 +15,10 @@ class DBTest extends \PHPUnit_Framework_TestCase
         $db = $client->createDatabase('test_zzz');
 
         for ($i = 0; $i < 144; $i++) {
-            $data = [['tags' => ['type' => $i % 2 ? 'two' : 'one'],
-            'fields' => ['value' => $i * 10,
-                'type' => $i % 2 ? 'two' : 'one'],
-            'timestamp' => strtotime("2015-01-01T00:00:00Z") + $i * 10 * 60]];
+            $data = array(array('tags' => array('type' => $i % 2 ? 'two' : 'one'),
+            'fields' => array('value' => $i * 10,
+                'type' => $i % 2 ? 'two' : 'one'),
+            'timestamp' => strtotime("2015-01-01T00:00:00Z") + $i * 10 * 60));
             $db->insert('test1', $data);
         }
     }

--- a/tests/DBTest.php
+++ b/tests/DBTest.php
@@ -8,6 +8,29 @@ use crodas\InfluxPHP\ResultSeriesObject;
 class DBTest extends \PHPUnit_Framework_TestCase
 {
 
+
+    public static function setUpBeforeClass() 
+    {
+        $client = new Client;
+        $db = $client->createDatabase('test_zzz');
+
+        for ($i = 0; $i < 144; $i++) {
+            $data = [['tags' => ['type' => $i % 2 ? 'two' : 'one'],
+            'fields' => ['value' => $i * 10,
+                'type' => $i % 2 ? 'two' : 'one'],
+            'timestamp' => strtotime("2015-01-01T00:00:00Z") + $i * 10 * 60]];
+            $db->insert('test1', $data);
+        }
+    }
+
+    public static function tearDownAfterClass()
+    {
+          $client = new Client;
+          $db = $client->test_zzz;
+          $db->drop();
+    }
+
+
     public function testCreate()
     {
         $client = new Client;
@@ -76,24 +99,22 @@ class DBTest extends \PHPUnit_Framework_TestCase
         $client->SetTimePrecision(array());
     }
 
+    /**
+     * @medium
+     */
     public function testInsert()
     {
         $client = new Client;
-        $db = $client->createDatabase('test_zzz');
+        $db = $client->test_zzz;
 
-        for ($i = 0; $i < 144; $i++) {
-            $data = [['tags' => ['type' => $i % 2 ? 'two' : 'one'],
-            'fields' => ['value' => $i * 10,
-                'type' => $i % 2 ? 'two' : 'one'],
-            'timestamp' => strtotime("2015-01-01T00:00:00Z") + $i * 10 * 60]];
-            $db->insert('test1', $data);
-        }
-        usleep(500000); // hope that's enough to be all values written
         $this->assertEquals($db->first("select * from test1 where value=0")->time, '2015-01-01T00:00:00Z');
         $this->assertEquals($db->first("select last(value) from test1")->last, 1430);
     }
 
-    /** @depends testInsert */
+    /** 
+      * @depends testInsert 
+      * @medium
+    */
     public function testQueryAggregateCount()
     {
         $client = new Client;
@@ -107,7 +128,10 @@ class DBTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($result[11]->count, 6);
     }
 
-    /** @depends testInsert */
+    /** 
+      * @depends testInsert 
+      * @medium
+    */
     public function testQueryAggregateMean()
     {
         $client = new Client;
@@ -120,7 +144,10 @@ class DBTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($result[11]->mean, 1405);
     }
 
-    /** @depends testInsert */
+    /** 
+      * @depends testInsert 
+      * @medium
+    */
     public function testQueryAggregateSum()
     {
         $client = new Client;
@@ -133,7 +160,10 @@ class DBTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($result[11]->sum, 8430);
     }
 
-    /** @depends testInsert */
+    /** 
+      * @depends testInsert 
+      * @medium
+    */
     public function testQueryAggregateFirst()
     {
         $client = new Client;
@@ -146,7 +176,10 @@ class DBTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($result[11]->first, 1380);
     }
 
-    /** @depends testInsert */
+    /** 
+      * @depends testInsert 
+      * @medium
+    */
     public function testQueryAggregateLast()
     {
         $client = new Client;
@@ -160,7 +193,10 @@ class DBTest extends \PHPUnit_Framework_TestCase
     }
 
 
-    /** @depends testInsert */
+    /** 
+      * @depends testInsert 
+      * @medium
+    */
     public function testQueryAggregateMultipleResultSeries()
     {
         $client = new Client;
@@ -188,7 +224,9 @@ class DBTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($result2[11]->count, 3);
     }
 
-    /** @depends testInsert 
+    /** 
+     * @depends testInsert 
+     * @medium
      * @expectedException RuntimeException
      */
     public function testDatabaseExists()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,10 +1,15 @@
 <?php
 
-require __DIR__ . "/../../../autoload.php";
+require __DIR__ . "/../vendor/autoload.php";
 
 $client = new \crodas\InfluxPHP\Client;
-foreach ($client->getDatabases() as $db) {
-    if (preg_match("/^test_/", $db->getName())) {
-        $db->drop();
-    }
+
+$dbs = $client->getDatabases();
+if ($dbs) {
+	foreach ($dbs as $db) {
+    	if (preg_match("/^test_/", $db->getName())) {
+    		$db->drop();
+    	}
+	}
+
 }


### PR DESCRIPTION
Hello!

I checked the Travis logs and restructured the DBtest.php to avoid the timing problem. The test insert is a little bit larger, so the dataset is not written and committed completely in the database, so the results are different from the expectations. Maybe it's better now, but we'll see it in the next Travis job. 
Additionally the tests should be PHP 5.3 compatible again, sorry for that issue. And the bootstrap file checks the existence of test databases without warning if the result is empty. 

Kind regards,
   Ralf
